### PR TITLE
Update Afterpay API version to V2

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ Workarea Afterpay orders use the following flow:
 3. User clicks place order button - an api call is made to get a token.
 4. If token creation is successful the token is injected into the DOM and the user is redirected to the Afterpay site.
 5. User enters payment details and submits payment.
-6. User is taken back to Workarea and payment is captured.
+6. User is taken back to Workarea and payment is authorized or captured.
 7. Order confirmation page is displayed.
 
-A diagram of the flow can be found here: https://docs.afterpay.com/us-online-api-v1.html#direct-payment-flow
+Afterpay API documentation can be found here: https://docs.afterpay.com/online-api-v2-b857508478e7.html
 
 Implementation Notes
 --------------------------------------------------------------------------------
@@ -80,13 +80,13 @@ The regional US and Australian API endpoints require separate credentials. You c
 Getting Started
 --------------------------------------------------------------------------------
 
-This gem contains a rails engine that must be mounted onto a host Rails application.
+Add the gem to your application's Gemfile:
 
-Add the gem to your application's Gemfile specifying the source:
-
-    # ...
-    gem 'workarea-afterpay'
-    # ...
+```ruby
+# ...
+gem 'workarea-afterpay'
+# ...
+```
 
 Update your application's bundle.
 

--- a/README.md
+++ b/README.md
@@ -26,12 +26,6 @@ A diagram of the flow can be found here: https://docs.afterpay.com/us-online-api
 Implementation Notes
 --------------------------------------------------------------------------------
 
-**Payment**
-
-Afterpay requires that all payments are captured when the order is placed. All Afterpay
-payments will perform a "Purchase" action instead of the default "Authorize"; meaning that Afterpay payments will be "captured" immediately. Other payment tenders will still behave as configured.
-
-
 **Product Detail Pages**
 
 This integration makes use of the ```storefront.product_pricing_details``` append point to display the Afterpay pricing on the product detail page. Some custom PDP templates may not have this append point.
@@ -88,29 +82,10 @@ Getting Started
 
 This gem contains a rails engine that must be mounted onto a host Rails application.
 
-To access Workarea gems and source code, you must be an employee of WebLinc or a licensed retailer or partner.
-
-Workarea gems are hosted privately at https://gems.weblinc.com/.
-You must have individual or team credentials to install gems from this server. Add your gems server credentials to Bundler:
-
-    bundle config gems.weblinc.com my_username:my_password
-
-Or set the appropriate environment variable in a shell startup file:
-
-    export BUNDLE_GEMS__WEBLINC__COM='my_username:my_password'
-
-Then add the gem to your application's Gemfile specifying the source:
+Add the gem to your application's Gemfile specifying the source:
 
     # ...
-    gem 'workarea-afterpay', source: 'https://gems.weblinc.com'
-    # ...
-
-Or use a source block:
-
-    # ...
-    source 'https://gems.weblinc.com' do
-      gem 'workarea-afterpay'
-    end
+    gem 'workarea-afterpay'
     # ...
 
 Update your application's bundle.
@@ -121,11 +96,9 @@ Update your application's bundle.
 Workarea Platform Documentation
 --------------------------------------------------------------------------------
 
-See [http://developer.workarea.com](http://developer.workarea.com) for Workarea platform documentation.
+See [https://developer.workarea.com](https://developer.workarea.com) for Workarea Commerce documentation.
 
-Copyright & Licensing
+License
 --------------------------------------------------------------------------------
 
-Copyright WebLinc 2018. All rights reserved.
-
-For licensing, contact sales@workarea.com.
+Workarea Afterpay is released under the [Business Software License](LICENSE)

--- a/app/controllers/workarea/storefront/afterpay_controller.rb
+++ b/app/controllers/workarea/storefront/afterpay_controller.rb
@@ -55,7 +55,7 @@ module Workarea
       ap_order_details = gateway.get_order(params[:orderToken])
       tender = payment.afterpay
 
-      unless (ap_order_details.body["totalAmount"]["amount"].to_m == tender.amount.to_m && current_checkout.complete?)
+      unless (ap_order_details.body["amount"]["amount"].to_m == tender.amount.to_m && current_checkout.complete?)
         flash[:error] = t('workarea.storefront.afterpay.payment_error')
         payment.clear_afterpay
         redirect_to(checkout_payment_path) && (return)

--- a/app/models/workarea/payment.decorator
+++ b/app/models/workarea/payment.decorator
@@ -26,17 +26,5 @@ module Workarea
       self.afterpay = nil
       super
     end
-
-    def authorize!(options = {})
-      transactions = tenders.map { |t| t.build_transaction(action: payment_action(t)) }
-      perform_operation(transactions, options)
-    end
-
-    private
-
-      def payment_action(tender)
-        tender.slug == :afterpay ? 'purchase' : 'authorize'
-      end
-
   end
 end

--- a/app/models/workarea/payment/authorize/afterpay.rb
+++ b/app/models/workarea/payment/authorize/afterpay.rb
@@ -1,7 +1,60 @@
 module Workarea
   class Payment
     module Authorize
-      Afterpay = Capture::Afterpay
+      class Afterpay
+        include OperationImplementation
+        include CreditCardOperation
+        include AfterpayPaymentGateway
+
+        def complete!
+          response = authorize
+          if response.success?
+            transaction.response = ActiveMerchant::Billing::Response.new(
+              true,
+              I18n.t(
+                'workarea.afterpay.authorize',
+                amount: transaction.amount
+              ),
+              response.body
+            )
+          else
+             transaction.response = ActiveMerchant::Billing::Response.new(
+               false,
+              I18n.t('workarea.afterpay.capture_failure'),
+              response.body
+            )
+          end
+        end
+
+        def cancel!
+          return unless transaction.success?
+
+          payment_id = transaction.response.params["id"]
+          response = gateway.void(payment_id)
+
+          transaction.cancellation = ActiveMerchant::Billing::Response.new(
+            true,
+              I18n.t('workarea.afterpay.void'),
+              response.body
+            )
+        end
+
+        private
+
+        def authorize
+          request_id = SecureRandom.uuid
+          auth_response = response(request_id)
+          if Workarea::Afterpay::RETRY_ERROR_STATUSES.include? auth_response.status
+            return response(request_id)
+          end
+
+          auth_response
+        end
+
+        def response(request_id)
+          gateway.authorize(tender.token, tender.payment.id, request_id)
+        end
+      end
     end
   end
 end

--- a/app/models/workarea/payment/capture/afterpay.rb
+++ b/app/models/workarea/payment/capture/afterpay.rb
@@ -7,7 +7,7 @@ module Workarea
         include AfterpayPaymentGateway
 
         def complete!
-          response = gateway.capture(tender.token, tender.payment.id)
+          response = capture
           if response.success?
             transaction.response = ActiveMerchant::Billing::Response.new(
               true,
@@ -29,6 +29,26 @@ module Workarea
         def cancel!
           # No op - no cancel functionality available.
         end
+
+        private
+          def payment_id
+            transaction.reference.response.params["id"]
+          end
+
+          def capture
+            request_id = SecureRandom.uuid
+            capture_response = response(request_id)
+
+            if Workarea::Afterpay::RETRY_ERROR_STATUSES.include? capture_response.status
+              return response(request_id)
+            end
+
+            capture_response
+          end
+
+          def response(request_id)
+            gateway.capture(payment_id, transaction.amount, request_id)
+          end
       end
     end
   end

--- a/app/models/workarea/payment/purchase/afterpay.rb
+++ b/app/models/workarea/payment/purchase/afterpay.rb
@@ -1,7 +1,52 @@
 module Workarea
   class Payment
     module Purchase
-      Afterpay = Capture::Afterpay
+      class Afterpay
+        include OperationImplementation
+        include CreditCardOperation
+        include AfterpayPaymentGateway
+
+        def complete!
+          response = purchase
+          if response.success?
+            transaction.response = ActiveMerchant::Billing::Response.new(
+              true,
+              I18n.t(
+                'workarea.afterpay.purchase',
+                amount: transaction.amount
+              ),
+              response.body
+            )
+          else
+             transaction.response = ActiveMerchant::Billing::Response.new(
+               false,
+              I18n.t('workarea.afterpay.purchase_failure'),
+              response.body
+            )
+          end
+        end
+
+        def cancel!
+          # No op - no cancel functionality available.
+        end
+
+        private
+
+        def purchase
+          request_id = SecureRandom.uuid
+          purchase_response = response(request_id)
+
+          if Workarea::Afterpay::RETRY_ERROR_STATUSES.include? purchase_response.status
+            return response(request_id)
+          end
+
+          purchase_response
+        end
+
+        def response(request_id)
+          gateway.purchase(tender.token, request_id)
+        end
+      end
     end
   end
 end

--- a/app/services/workarea/afterpay/order_builder.rb
+++ b/app/services/workarea/afterpay/order_builder.rb
@@ -2,6 +2,11 @@ module Workarea
   module Afterpay
     class OrderBuilder
 
+      module ProductUrl
+        include Workarea::I18n::DefaultUrlOptions
+        include Storefront::Engine.routes.url_helpers
+        extend self
+      end
       attr_reader :order
 
       # @param  ::Workarea::Order
@@ -11,7 +16,7 @@ module Workarea
 
       def build
         {
-          totalAmount: {
+         amount: {
             amount: order.order_balance.to_s,
             currency: currency_code,
           },
@@ -58,7 +63,7 @@ module Workarea
         def address(address_obj)
           {
             name: "#{address_obj.first_name} #{address_obj.last_name}",
-            suburb: address_obj.city,
+            area1: address_obj.city,
             line1: address_obj.street,
             state: address_obj.region,
             postcode: address_obj.postal_code,
@@ -74,6 +79,7 @@ module Workarea
               name: product.name,
               sku: oi.sku,
               quantity: oi.quantity,
+              pageUrl: ProductUrl.product_url(id: oi.product.to_param, host: Workarea.config.host),
               price: {
                 amount: oi.original_unit_price.to_s,
                 currency: currency_code

--- a/app/view_models/workarea/storefront/afterpay_view_model.rb
+++ b/app/view_models/workarea/storefront/afterpay_view_model.rb
@@ -5,7 +5,7 @@ module Workarea
     # Orders must be between the min and max order total to qualify.
     def order_total_in_range?
       return unless afterpay_configuration.present?
-      eligible_options.present?
+      order.order_balance >= min_price && order.order_balance <= max_price
     end
 
     # Show if admin settings are enabled, there are configuration options returned
@@ -25,26 +25,18 @@ module Workarea
       show? && afterpay_settings.display_on_pdp?
     end
 
-    # TODO - handle what to display if there are multiple
-    # eligible display options. Docs do not seem to
-    # indicate there would ever be more than one.
-    def display_option
-      eligible_options.first
-    end
 
     def installment_price
       order.order_balance / Workarea.config.afterpay[:installment_count]
     end
 
     def min_price
-      config = afterpay_configuration.first
-      return 0.to_m unless config[:minimumAmount].present?
-      config[:minimumAmount][:amount].to_m
+      return 0.to_m unless afterpay_configuration[:minimumAmount].present?
+      afterpay_configuration[:minimumAmount][:amount].to_m
     end
 
     def max_price
-      config = afterpay_configuration.first
-      config[:maximumAmount][:amount].to_m
+      afterpay_configuration[:maximumAmount][:amount].to_m
     end
 
     def afterpay_country
@@ -52,12 +44,6 @@ module Workarea
     end
 
     private
-      def eligible_options
-        ap_options = afterpay_configuration.select do |ap|
-          order.order_balance >= min_price && order.order_balance <= max_price
-        end
-      end
-
       def afterpay_configuration
         options[:afterpay_configuration]
       end

--- a/app/view_models/workarea/storefront/product_view_model.decorator
+++ b/app/view_models/workarea/storefront/product_view_model.decorator
@@ -9,9 +9,8 @@ module Workarea
       return unless afterpay_settings.enabled? && afterpay_settings.display_on_pdp?
       return unless afterpay_location_configuration.present?
 
-      afterpay_location_configuration.any? do |ap|
-        pricing.sell_min_price >= min_price && pricing.sell_min_price <= max_price
-      end
+      pricing.sell_min_price >= min_price && pricing.sell_min_price <= max_price
+
     end
 
     def installment_price
@@ -21,14 +20,12 @@ module Workarea
     private
 
       def min_price
-        config = afterpay_location_configuration.first.with_indifferent_access
-        return 0.to_m unless config[:minimumAmount].present?
-        config[:minimumAmount][:amount].to_m
+        return 0.to_m unless afterpay_location_configuration[:minimumAmount].present?
+        afterpay_location_configuration[:minimumAmount][:amount].to_m
       end
 
       def max_price
-        config = afterpay_location_configuration.first.with_indifferent_access
-        config[:maximumAmount][:amount].to_m
+        afterpay_location_configuration[:maximumAmount][:amount].to_m
       end
 
       def afterpay_location
@@ -40,7 +37,7 @@ module Workarea
       end
 
       def afterpay_location_configuration
-        afterpay_configuration(afterpay_location)
+        afterpay_configuration(afterpay_location).with_indifferent_access
       end
 
       def afterpay_settings

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -52,9 +52,14 @@ en:
         afterpay: Afterpay
         learn_more: Learn More
     afterpay:
+      authorize: "%{amount} has been authorized"
       capture: "%{amount} has been captured"
+      purchase: "%{amount} has been purchased"
       refund: "%{amount} has been refunded"
+      refund: "Aftperay Transaction has been voided"
+      authorize_failure: "Afterpay authorize has failed"
       capture_failure: "Afterpay capture has failed"
+      purchase_failure: "Afterpay purchase has failed"
       refund_failure: "Afterpay refund has failed"
       tender_description: "Afterpay: %{installment_count} installments of %{installment_price}"
       dialog:

--- a/lib/workarea/afterpay.rb
+++ b/lib/workarea/afterpay.rb
@@ -14,7 +14,9 @@ require "faraday"
 
 module Workarea
   module Afterpay
-     def self.credentials
+    RETRY_ERROR_STATUSES = 500..599
+
+    def self.credentials
       (Rails.application.secrets.afterpay || {}).deep_symbolize_keys
     end
 

--- a/lib/workarea/afterpay/bogus_gateway.rb
+++ b/lib/workarea/afterpay/bogus_gateway.rb
@@ -6,10 +6,7 @@ module Workarea
       end
 
       def get_configuration
-        b = [
-          {
-            "type": "PAY_BY_INSTALLMENT",
-            "description": "Pay over time",
+        b = {
             "minimumAmount": {
                  "amount": "5.00",
                  "currency": "USD"
@@ -19,7 +16,7 @@ module Workarea
                 "currency": "USD"
             }
           }
-        ]
+
         Response.new(response(b))
       end
 
@@ -78,7 +75,7 @@ module Workarea
                   "currency": "USD"
               },
               "token": "9tlqhfgebl6mu2g9t98rre2ia25ri2hvadc4aaimvpca1p9fma5j",
-              "totalAmount": {
+              "amount": {
                   "amount": "95.30",
                   "currency": "USD"
               }
@@ -95,11 +92,25 @@ module Workarea
         Response.new(response(b))
       end
 
-      def capture(token, order_id = "")
+      def capture(payment_id, amount, request_id)
+        Response.new(response(payment_response_body, 200))
+      end
+
+      def authorize(token, order_id = "", request_id)
+        if token == "error_token"
+          Response.new(response(capture_error_response_body, 402))
+        elsif token == "timeout_token"
+          Response.new(response(nil, 502))
+        else
+          Response.new(response(payment_response_body, 200))
+        end
+      end
+
+      def purchase(token, order_id = "", request_id)
         if token == "error_token"
           Response.new(response(capture_error_response_body, 402))
         else
-          Response.new(response(capture_response_body, 200))
+          Response.new(response(payment_response_body, 200))
         end
       end
 
@@ -116,6 +127,10 @@ module Workarea
         }
 
         Response.new(response(b))
+      end
+
+      def void(payment_id)
+        Response.new(response(payment_response_body))
       end
 
       private
@@ -138,7 +153,7 @@ module Workarea
           }
         end
 
-        def capture_response_body
+        def payment_response_body
           {
             "id": "12345678",
              "token": "q54l9qd907m6iqqqlcrm5tpbjjsnfo47vsm59gqrfnd2rqefk9hu",

--- a/lib/workarea/afterpay/response.rb
+++ b/lib/workarea/afterpay/response.rb
@@ -10,7 +10,12 @@ module Workarea
       end
 
       def body
-        @body ||= JSON.parse(@response.body)
+        return {} unless @response.body.present? && @response.body != "null"
+        JSON.parse(@response.body)
+      end
+
+      def status
+        @response.status
       end
     end
   end

--- a/test/integration/workarea/storefront/afterpay_integration_test.rb
+++ b/test/integration/workarea/storefront/afterpay_integration_test.rb
@@ -135,7 +135,7 @@ module Workarea
         transactions = payment.tenders.first.transactions
         assert_equal(1, transactions.size)
         assert(transactions.first.success?)
-        assert_equal('purchase', transactions.first.action)
+        assert_equal('authorize', transactions.first.action)
       end
 
 
@@ -183,7 +183,7 @@ module Workarea
 
         ap_tender = payment.tenders.detect { |t| t.slug == :afterpay }
         assert(ap_tender.transactions.first.success?)
-        assert_equal('purchase', ap_tender.transactions.first.action)
+        assert_equal('authorize', ap_tender.transactions.first.action)
 
         sc_tender = payment.tenders.detect { |t| t.slug == :store_credit }
         assert(sc_tender.transactions.first.success?)
@@ -221,21 +221,21 @@ module Workarea
 
       def get_order_response(amount)
         b = {
-              "totalAmount": {
+              "amount": {
                 "amount": "#{amount}",
                 "currency": "USD"
+              }
             }
-          }
           Workarea::Afterpay::Response.new(response(b))
       end
 
       def response(body, status = 200)
         response = Faraday.new do |builder|
           builder.adapter :test do |stub|
-            stub.get("/v1/bogus") { |env| [ status, {}, body.to_json ] }
+            stub.get("/v2/bogus") { |env| [ status, {}, body.to_json ] }
           end
         end
-        response.get("/v1/bogus")
+        response.get("/v2/bogus")
       end
     end
   end

--- a/test/services/workarea/afterpay/order_builder_test.rb
+++ b/test/services/workarea/afterpay/order_builder_test.rb
@@ -19,7 +19,7 @@ module Workarea
         payment.reload
         order_hash = Workarea::Afterpay::OrderBuilder.new(order).build
 
-        assert_equal(9.00, order_hash[:totalAmount][:amount].to_f)
+        assert_equal(9.00, order_hash[:amount][:amount].to_f)
         assert_equal(1.00, order_hash[:shippingAmount][:amount].to_f)
         assert_equal(0.00, order_hash[:taxAmount][:amount].to_f)
         assert_equal(order.id, order_hash[:merchantReference])
@@ -31,8 +31,8 @@ module Workarea
         assert_equal(1, order_hash[:discounts].size)
         assert_equal("Order Total Discount", order_hash[:discounts].first[:displayName])
 
-        assert_equal("Philadelphia", order_hash[:shipping][:suburb])
-        assert_equal("Wilmington", order_hash[:billing][:suburb])
+        assert_equal("Philadelphia", order_hash[:shipping][:area1])
+        assert_equal("Wilmington", order_hash[:billing][:area1])
 
         assert_equal(1, order_hash[:items].size)
         assert_equal("SKU", order_hash[:items].first[:sku])
@@ -79,7 +79,6 @@ module Workarea
           },
           shipping_service: shipping_service.name,
         )
-
 
         order
       end

--- a/test/view_models/workarea/storefront/afterpay_view_model_test.rb
+++ b/test/view_models/workarea/storefront/afterpay_view_model_test.rb
@@ -61,16 +61,6 @@ module Workarea
         refute(view_model.afterpay_country.present?)
       end
 
-      def test_display_options
-        @order.total_price = 25.00
-
-        checkout = Workarea::Checkout.new(@order, @user)
-        view_model = Workarea::Storefront::AfterpayViewModel.new(checkout, { afterpay_configuration: afterpay_options, order: @order })
-
-        assert_equal("PAY_BY_INSTALLMENT", view_model.display_option[:type])
-        assert_equal("Pay over time", view_model.display_option[:description])
-      end
-
       def test_installment_price
         @order.total_price = 100.00
         view_model = Workarea::Storefront::AfterpayViewModel.new(nil, { afterpay_configuration: afterpay_options, order: @order })
@@ -80,20 +70,16 @@ module Workarea
 
       private
         def afterpay_options
-          [
-            {
-              "type": "PAY_BY_INSTALLMENT",
-              "description": "Pay over time",
-              "minimumAmount": {
-                   "amount": "20.00",
-                   "currency": "USD"
-               },
-              "maximumAmount": {
-                  "amount": "30.00",
-                  "currency": "USD"
-              }
+          {
+            "minimumAmount": {
+                 "amount": "20.00",
+                 "currency": "USD"
+             },
+            "maximumAmount": {
+                "amount": "30.00",
+                "currency": "USD"
             }
-          ]
+          }
         end
     end
   end


### PR DESCRIPTION
New API version allows for a traditional auth then capture
model of handling payments