### PR TITLE
Ruby 3.2+ Compatibility Updates

### DIFF
--- a/app/controllers/workarea/admin/afterpay/configurations_controller.rb
+++ b/app/controllers/workarea/admin/afterpay/configurations_controller.rb
@@ -9,7 +9,7 @@ module Workarea
         end
 
         def update
-          if configuration.update_attributes(configuration_params)
+          if configuration.update(configuration_params)
             redirect_to admin.edit_afterpay_configuration_path, flash: { success: t('workarea.admin.afterpay_configuration.edit.flash_messages.updated') }
           else
             flash[:error] = t('workarea.admin.afterpay_configuration.edit.flash_messages.save_error')

--- a/app/controllers/workarea/storefront/afterpay_controller.rb
+++ b/app/controllers/workarea/storefront/afterpay_controller.rb
@@ -29,7 +29,7 @@ module Workarea
 
       # set the token on the order so we can more easily look up the order
       # when returning from afterpay
-      current_order.update_attributes!(afterpay_token: token)
+      current_order.update!(afterpay_token: token)
 
       redirect_to checkout_payment_path
     end
@@ -61,7 +61,7 @@ module Workarea
         redirect_to(checkout_payment_path) && (return)
       end
 
-      payment.afterpay.update_attributes!(ready_to_capture: true)
+      payment.afterpay.update!(ready_to_capture: true)
 
       # place the order.
       if current_checkout.place_order

--- a/test/integration/workarea/storefront/afterpay_integration_test.rb
+++ b/test/integration/workarea/storefront/afterpay_integration_test.rb
@@ -160,7 +160,7 @@ module Workarea
         payment = Payment.find(order.id)
         payment.profile = create_payment_profile(email: order.email)
 
-        payment.profile.update_attributes!(store_credit: 1.00)
+        payment.profile.update!(store_credit: 1.00)
         payment.set_store_credit
         payment.tenders.first.amount = 1.to_m
         payment.save!

--- a/test/services/workarea/afterpay/order_builder_test.rb
+++ b/test/services/workarea/afterpay/order_builder_test.rb
@@ -9,7 +9,7 @@ module Workarea
 
         # apply store credit
         payment = Workarea::Payment.find(order.id)
-        payment.profile.update_attributes!(store_credit: 1.00)
+        payment.profile.update!(store_credit: 1.00)
         payment.set_store_credit
         payment.tenders.first.amount = 1.to_m
         payment.save

--- a/workarea-afterpay.gemspec
+++ b/workarea-afterpay.gemspec
@@ -20,4 +20,5 @@ Gem::Specification.new do |s|
   s.add_dependency 'workarea', '~> 3.x'
 
   s.add_dependency "faraday", "~> 0.10"
+s.required_ruby_version = ['>= 2.7', '< 3.5']
 end


### PR DESCRIPTION
## Summary
Ruby 3.2+ compatibility updates for this plugin.

### Changes
- Updated gemspec: `required_ruby_version = ['>= 2.7', '< 3.5']`
- Replaced deprecated API calls (update_attributes → update, etc.) if found
- Fixed any Ruby 3.x keyword argument incompatibilities if found

## Client impact
None — backward compatible changes only.

## Verification
Gemspec constraints verified. Common deprecated pattern replacements applied.